### PR TITLE
Add PHP 8.0 version test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
+          - "7.4"
         operating-system:
           - "ubuntu-latest"
     steps:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
+          - "7.4"
         operating-system:
           - "ubuntu-latest"
     steps:
@@ -77,9 +77,8 @@ jobs:
           - "locked"
           - "highest"
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
+          - "8.0"
         operating-system:
           - "ubuntu-latest"
     steps:

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-openssl": "*",
-        "lcobucci/clock": "^1.2"
+        "lcobucci/clock": "^1.4"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "vimeo/psalm": "^3.11",
+        "vimeo/psalm": "^4.1",
         "friendsofphp/php-cs-fixer": "^2.16"
     },
     "scripts": {

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -34,7 +34,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />


### PR DESCRIPTION
# Changed log

- Adding `php-8.0` version test during GitHub Action.
- To support the `SystemClock::fromUTC` method, it should define the `` on `composer.json`.
And dropping the `php-7.2`, `php-7.3` versions and let `php-7.4` version be minimum requirements for this package.
- Upgrading the Psalm version to be `^4.1` and improve `psalm.xml.dist` file.