### PR TITLE
Using the Composer scripts setting to run scripts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,12 +54,8 @@ jobs:
       - name: "Install locked dependencies"
         if: ${{ matrix.dependencies == 'locked' }}
         run: "composer install ${{ env.COMPOSER_FLAGS }}"
-      - name: "Run PHP CS Fixer"
-        run: "php vendor/bin/php-cs-fixer fix --dry-run -vvv"
-      - name: "Run Psalm"
-        run: "php vendor/bin/psalm --stats --no-cache --show-info=true"
-      - name: "Run PHPUnit"
-        run: "php vendor/bin/phpunit --coverage-text --testsuite=unit"
+      - name: "Run PHP CS Fixer, Psalm and PHPUnit"
+        run: "composer check-all"
 
   release:
     name: "Release"

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,15 @@
         "phpunit/phpunit": "^9.5",
         "vimeo/psalm": "^4.22",
         "friendsofphp/php-cs-fixer": "^3.8"
+    },
+    "scripts": {
+        "phpcs": "vendor/bin/php-cs-fixer fix --dry-run -vvv",
+        "psalm": "vendor/bin/psalm --stats --no-cache --show-info=true",
+        "phpunit": "vendor/bin/phpunit --coverage-text --testsuite=unit",
+        "check-all": [
+            "@phpcs",
+            "@psalm",
+            "@phpunit"
+        ]
     }
 }


### PR DESCRIPTION
# Changed log

- Using the Composer scripts setting to run scripts so that it can be helpful and convenient for developers to run scripts when developing/contributing the repository.